### PR TITLE
Add .travis.yml and tox.ini for automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+    - "2.7"
+cache:
+    directories:
+        - $HOME/spark
+addons:
+    apt:
+        packages:
+            - libsnappy-dev
+before_install: 
+    - export PATH=$HOME/.local/bin:$PATH
+install: 
+    - pip install tox-travis codecov
+    - "[ -f spark ] || mkdir spark && cd spark && wget http://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz && cd .."
+    - tar -xf ./spark/spark-2.0.0-bin-hadoop2.7.tgz
+    - export SPARK_HOME=`pwd`/spark-2.0.0-bin-hadoop2.7
+    - export PYTHONPATH=${SPARK_HOME}/python/:$(echo ${SPARK_HOME}/python/lib/py4j-*-src.zip):${PYTHONPATH}
+script: 
+    - tox
+after_success:
+    - codecov

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,12 @@ setup(name='python_etl',
       author_email='harterrt@mozilla.com',
       url='https://github.com/mozilla/python_etl.git',
       packages=find_packages(exclude=['tests']),
-)
+      install_requires=[
+          'python_moztelemetry',
+          ],
+      test_requires=[
+          'pytest',
+          'coverage',
+          'pytest-cov'
+          ]
+      )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27
+
+[pytest]
+addopts = --cov=python_etl tests/
+
+[testenv]
+commands = pytest
+passenv = PYTHONPATH
+setenv =
+    PYTHONPATH = {env:PYTHONPATH}
+    SPARK_HOME = {env:SPARK_HOME}
+deps =
+    pytest
+    pytest-cov
+    coverage


### PR DESCRIPTION
This should let this repository be run under continuous integration using travis and codecov.io. I've tested this against my `churn-port` branch. 

This uses tox for setting up the environment and test-runner. As long as you have your `PYTHONPATH` set correctly with the pyspark and py4j dependencies, you should be able to run `tox` to run tests.

Alternatively, you can run pytest directly if you want more flexibility. The dependencies for pytest are in setup.py for setting up your own virtualenv. 