### PR TITLE
Add testpilot ETL jobs and basic_etl library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
 *.pyc
 
-.cache/
-
 dist/
 build/
 .tox/
 .coverage
-*.egg-info/
+.cache/
 
+*.egg-info/

--- a/python_etl/basic_etl/__init__.py
+++ b/python_etl/basic_etl/__init__.py
@@ -1,0 +1,1 @@
+from .transform import *

--- a/python_etl/basic_etl/transform.py
+++ b/python_etl/basic_etl/transform.py
@@ -1,0 +1,54 @@
+from pyspark.sql.types import StructType, StructField
+from collections import namedtuple
+from moztelemetry import get_pings_properties
+
+ColumnConfig = namedtuple('ColumnConfig',
+                          ['name', 'path', 'cleaning_func', 'struct_type'])
+
+
+class DataFrameConfig:
+    def __init__(self, col_configs, ping_filter):
+        self.columns = [ColumnConfig(*col) for col in col_configs]
+        self.ping_filter = ping_filter
+
+    def toStructType(self):
+        return StructType(map(
+            lambda col: StructField(col.name, col.struct_type, True),
+            self.columns))
+
+    def get_paths(self):
+        return map(lambda col: col.path, self.columns)
+
+
+def convert_pings(sqlContext, pings, data_frame_config):
+    """Performs basic data pipelining on raw telemetry pings """
+    filtered_pings = get_pings_properties(pings, data_frame_config.get_paths())\
+        .filter(data_frame_config.ping_filter)
+
+    return convert_rdd(sqlContext, filtered_pings, data_frame_config)
+
+
+def convert_rdd(sqlContext, raw_data, data_frame_config):
+    """Performs basic data pipelining over an RDD, returning a DataFrame
+
+    raw_data must have a map method.
+    """
+    def build_cell(ping, column_config):
+        """Take a json ping and a ColumnConfig and return a cleaned cell"""
+        raw_value = ping[column_config.path]
+        func = column_config.cleaning_func
+        if func is not None:
+            try:
+                return func(raw_value)
+            except:
+                return None
+        else:
+            return raw_value
+
+    def ping_to_row(ping):
+        return [build_cell(ping, col) for col in data_frame_config.columns]
+
+    return sqlContext.createDataFrame(
+        raw_data.map(ping_to_row),
+        schema=data_frame_config.toStructType()
+    )

--- a/python_etl/testpilot/containers.py
+++ b/python_etl/testpilot/containers.py
@@ -1,0 +1,30 @@
+from python_etl.basic_etl import convert_pings, DataFrameConfig
+from utils import testpilot_etl_boilerplate
+
+from pyspark.sql.types import StringType, LongType
+
+
+def transform_pings(sqlContext, pings):
+    return convert_pings(
+        sqlContext,
+        pings,
+        DataFrameConfig([
+            ("uuid", "payload/payload/uuid", None, StringType()),
+            ("userContextId", "payload/payload/userContextId", None, StringType()),
+            ("clickedContainerTabCount", "payload/payload/clickedContainerTabCount", None, LongType()),
+            ("eventSource", "payload/payload/eventSource", None, StringType()),
+            ("event", "payload/payload/event", None, StringType()),
+            ("hiddenContainersCount", "payload/payload/hiddenContainersCount", None, LongType()),
+            ("shownContainersCount", "payload/payload/shownContainersCount", None, LongType()),
+            ("totalContainersCount", "payload/payload/totalContainersCount", None, LongType()),
+            ("totalContainerTabsCount", "payload/payload/totalContainerTabsCount", None, LongType()),
+            ("totalNonContainerTabsCount", "payload/payload/totalNonContainerTabsCount", None, LongType()),
+            ("test", "payload/test", None, StringType()),
+        ], lambda ping: ping['payload/test'] == "@testpilot-containers")
+    )
+
+
+etl_job = testpilot_etl_boilerplate(
+    transform_pings,
+    's3n://telemetry-parquet/harter/containers_testpilottest/v1'
+)

--- a/python_etl/testpilot/pulse.py
+++ b/python_etl/testpilot/pulse.py
@@ -1,0 +1,91 @@
+from python_etl.basic_etl import DataFrameConfig, convert_pings
+from utils import testpilot_etl_boilerplate
+
+import dateutil.parser
+from pyspark.sql.types import (LongType, DoubleType, BooleanType, StringType,
+                               TimestampType, ArrayType, MapType, StructType,
+                               StructField)
+from pyspark.sql import Row
+
+
+class Request:
+    def __option__(func):
+        return lambda x: func(x) if x is not None else None
+
+    int_type = (__option__(int), LongType())
+    float_type = (__option__(float), DoubleType())
+
+    field_types = {
+        'num': int_type,
+        'cached': float_type,
+        'cdn': float_type,
+        'time': int_type,
+    }
+
+    StructType = StructType([
+        # For some reason, field_types needs to be sorted. Use
+        # PYTHONHASHSEED = 3201792604 to reproduce failure
+        StructField(key, field_types[key][1], True) for key in sorted(field_types)
+    ])
+
+    def __init__(self, request_dict):
+        args = {field: conversion(request_dict.get(field))
+                for field, (conversion, sql_type) in Request.field_types.items()}
+        self.row = Row(**args)
+
+
+def transform_pings(sqlContext, pings):
+    def requests_to_rows(requests):
+        out = {k: Request(v).row for k, v in requests.items()}
+        return out
+
+    RequestsType = MapType(StringType(), Request.StructType)
+
+    return convert_pings(
+        sqlContext,
+        pings,
+        DataFrameConfig([
+            ("method", "payload/payload/method", None, StringType()),
+            ("id", "payload/payload/id", None, StringType()),
+            ("type", "payload/payload/type", None, StringType()),
+            ("object", "payload/payload/object", None, StringType()),
+            ("category", "payload/payload/category", None, StringType()),
+            ("variant", "payload/payload/variant", None, StringType()),
+            ("details", "payload/payload/details", None, StringType()),
+            ("sentiment", "payload/payload/sentiment", None, LongType()),
+            ("reason", "payload/payload/reason", None, StringType()),
+            ("adBlocker", "payload/payload/adBlocker", None, BooleanType()),
+            ("addons", "payload/payload/addons", None, ArrayType(StringType())),
+            ("channel", "payload/payload/channel", None, StringType()),
+            ("hostname", "payload/payload/hostname", None, StringType()),
+            ("language", "payload/payload/language", None, StringType()),
+            ("openTabs", "payload/payload/openTabs", None, LongType()),
+            ("openWindows", "payload/payload/openWindows", None, LongType()),
+            ("platform", "payload/payload/platform", None, StringType()),
+            ("protocol", "payload/payload/protocol", None, StringType()),
+            ("telemetryId", "payload/payload/telemetryId", None, StringType()),
+            ("timerContentLoaded", "payload/payload/timerContentLoaded", None, LongType()),
+            ("timerFirstInteraction", "payload/payload/timerFirstInteraction", None, LongType()),
+            ("timerFirstPaint", "payload/payload/timerFirstPaint", None, LongType()),
+            ("timerWindowLoad", "payload/payload/timerWindowLoad", None, LongType()),
+            ("inner_timestamp", "payload/payload/timestamp", None, LongType()),
+            ("fx_version", "payload/payload/fx_version", None, StringType()),
+            ("creation_date", "creationDate", dateutil.parser.parse, TimestampType()),
+            ("test", "payload/test", None, StringType()),
+            ("variants", "payload/variants", None, StringType()),
+            ("timestamp", "payload/timestamp", None, LongType()),
+            ("version", "payload/version", None, StringType()),
+            ("requests", "payload/payload/requests", requests_to_rows, RequestsType),
+            ("disconnectRequests", "payload/payload/disconnectRequests", None, LongType()),
+            ("consoleErrors", "payload/payload/consoleErrors", None, LongType()),
+            ("e10sStatus", "payload/payload/e10sStatus", None, LongType()),
+            ("e10sProcessCount", "payload/payload/e10sProcessCount", None, LongType()),
+            ("trackingProtection", "payload/payload/trackingProtection", None, BooleanType())
+        ], lambda ping: ping['payload/test'] == 'pulse@mozilla.com')
+    )
+
+
+etl_job = testpilot_etl_boilerplate(
+    transform_pings,
+    's3://telemetry-parquet/testpilot/txp_pulse/v1'
+)

--- a/python_etl/testpilot/utils.py
+++ b/python_etl/testpilot/utils.py
@@ -1,0 +1,25 @@
+from datetime import date, timedelta
+from moztelemetry.dataset import Dataset
+
+
+def testpilot_etl_boilerplate(transform_func, s3_path):
+    def etl_job(sc, sqlContext, submission_date=None, save=True):
+        if submission_date is None:
+            submission_date = (date.today() - timedelta(1)).strftime("%Y%m%d")
+
+        pings = Dataset.from_source("telemetry")\
+            .where(docType="testpilottest")\
+            .where(submissionDate=submission_date)\
+            .where(appName="Firefox")\
+            .records(sc)
+
+        transformed_pings = transform_func(sqlContext, pings)
+
+        if save:
+            # path = 's3://telemetry-parquet/testpilot/txp_pulse/v1/submission_date={}'
+            path = s3_path + '/submission_date={}'.format(submission_date)
+            transformed_pings.repartition(1).write.mode('overwrite').parquet(path)
+
+        return transformed_pings
+
+    return etl_job

--- a/tests/pulse_ping.json
+++ b/tests/pulse_ping.json
@@ -1,0 +1,78 @@
+{
+  "payload":
+  {
+    "method": "pulse-submitted",
+    "test": "pulse@mozilla.com",
+    "version": "1.0.2",
+    "object": null,
+    "category": "interactions",
+    "variant": null,
+    "variants": null,
+    "timestamp": 76543,
+  
+    "payload": {
+      "details": "test",
+      "id": "19e0cf07-8145-4666-938d-811397db85dc",
+      "sentiment": 5,
+      "reason": "like",
+      "requests": {
+        "all": {
+          "num": 12,
+          "time": 4978,
+          "cached": 0.08333333333333333,
+          "cdn": 0
+        },
+        "main_frame": {
+          "num": 1,
+          "time": 726,
+          "cached": 0,
+          "cdn": 0
+        },
+        "sub_frame": {},
+        "stylesheet": {},
+        "script": {},
+        "image": {},
+        "object": {},
+        "xmlhttprequest": {},
+        "xbl": {},
+        "xslt": {},
+        "ping": {},
+        "beacon": {},
+        "xml_dtd": {},
+        "font": {},
+        "media": {},
+        "websocket": {},
+        "csp_report": {},
+        "imageset": {},
+        "web_manifest": {},
+        "other": {}
+      },
+      "disconnectRequests": 1,
+      "adBlocker": true,
+      "addons": [
+        "pulse@mozilla.com",
+        "inspector@mozilla.org",
+        "DevPrefs@jetpack",
+        "@min-vid"
+      ],
+      "channel": "developer",
+      "consoleErrors": 0,
+      "e10sStatus": 1,
+      "e10sProcessCount": 4,
+      "hostname": "github.com",
+      "language": "en-US",
+      "openTabs": 7,
+      "openWindows": 2,
+      "platform": "darwin",
+      "protocol": "https:",
+      "telemetryId": "549a6456-32c2-e048-8310-d22ccfa9fee1",
+      "timerContentLoaded": 589,
+      "timerFirstInteraction": null,
+      "timerFirstPaint": 41,
+      "timerWindowLoad": 1005,
+      "timestamp": 1487862372503,
+      "trackingProtection": false,
+      "version": "53.0a2"
+    }
+  }
+}

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,0 +1,77 @@
+from pyspark.sql import SQLContext
+from python_etl.testpilot.containers import transform_pings
+from utils import row_to_dict, spark_context
+
+
+def create_ping_rdd(sc, payload):
+    return sc.parallelize([
+        {'payload': {
+            'test': '@testpilot-containers',
+            'other-ignored-field': 'who cares',
+            'payload': payload
+        }}
+    ])
+
+
+def create_row(overrides):
+    keys = ["uuid", "userContextId", "clickedContainerTabCount", "eventSource",
+            "event", "hiddenContainersCount", "shownContainersCount",
+            "totalContainersCount", "totalContainerTabsCount",
+            "totalNonContainerTabsCount", "test"]
+
+    overrides['test'] = '@testpilot-containers'
+
+    return {key: overrides.get(key, None) for key in keys}
+
+
+def test_open_container_ping(spark_context):
+    input_payload = {
+        'uuid': 'a',
+        'userContextId': 10,
+        'clickedContainerTabCount': 20,
+        'event': 'open-tab',
+        'eventSource': 'tab-bar'
+    }
+
+    result_payload = input_payload
+    result_payload['userContextId'] = '10'
+
+    actual = transform_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(result_payload)
+
+
+def test_edit_container_ping(spark_context):
+    input_payload = {
+        'uuid': 'b',
+        'event': 'edit-containers'
+    }
+
+    actual = transform_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(input_payload)
+
+
+def test_hide_container_ping(spark_context):
+    input_payload = {
+        'uuid': 'a',
+        'userContextId': 'firefox-default',
+        'clickedContainerTabCount': 5,
+        'event': "hide-tabs",
+        'hiddenContainersCount': 2,
+        'shownContainersCount': 3,
+        'totalContainersCount': 5,
+    }
+
+    actual = transform_pings(
+        SQLContext(spark_context),
+        create_ping_rdd(spark_context, input_payload)
+    ).take(1)[0]
+
+    assert row_to_dict(actual) == create_row(input_payload)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,24 +1,7 @@
 import pytest
 from pyspark.sql import SparkSession
 from python_etl import *
-
-# Initialize a spark context:
-
-
-@pytest.fixture(scope="session")
-def spark_context(request):
-    spark = (SparkSession
-             .builder
-             .appName("python_etl_test")
-             .getOrCreate())
-
-    sc = spark.sparkContext
-
-    # teardown
-    request.addfinalizer(lambda: spark.stop())
-
-    return sc
-
+from utils import *
 
 # Generate some data
 def create_row(client_id, os):

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -1,0 +1,84 @@
+import pytest
+import json
+from pyspark.sql import SQLContext, Row
+from python_etl.testpilot.pulse import transform_pings
+from utils import spark_context, row_to_dict
+
+
+def create_row():
+    with open('tests/pulse_ping.json') as infile:
+        return json.load(infile)
+
+
+@pytest.fixture
+def simple_rdd(spark_context):
+    return spark_context.parallelize([create_row()])
+
+
+def test_simple_transform(simple_rdd, spark_context):
+    actual = transform_pings(SQLContext(spark_context), simple_rdd).take(1)[0]
+
+    empty_request_keys = ["sub_frame", "stylesheet", "script", "image",
+                          "object", "xmlhttprequest", "xbl", "xslt", "ping",
+                          "beacon", "xml_dtd", "font", "media", "websocket",
+                          "csp_report", "imageset", "web_manifest", "other"]
+    empty_request = Row(cached=None, cdn=None, num=None, time=None)
+
+    requests = dict(
+        [(key, empty_request) for key in empty_request_keys] + [
+            ("all", Row(
+                num=12,
+                time=4978,
+                cached=0.08333333333333333,
+                cdn=0
+            )),
+            ("main_frame", Row(
+                num=1,
+                time=726,
+                cached=0,
+                cdn=0
+            ))
+        ]
+    )
+
+    expected = {
+        'method': None,
+        'id': u'19e0cf07-8145-4666-938d-811397db85dc',
+        'type': None,
+        'object': None,
+        'category': None,
+        'variant': None,
+        'details': u'test',
+        'sentiment': 5,
+        'reason': u'like',
+        'adBlocker': True,
+        'addons': [u'pulse@mozilla.com', u'inspector@mozilla.org',
+                   u'DevPrefs@jetpack', u'@min-vid'],
+        'channel': u'developer',
+        'hostname': u'github.com',
+        'language': u'en-US',
+        'openTabs': 7,
+        'openWindows': 2,
+        'platform': u'darwin',
+        'protocol': u'https:',
+        'telemetryId': u'549a6456-32c2-e048-8310-d22ccfa9fee1',
+        'timerContentLoaded': 589,
+        'timerFirstInteraction': None,
+        'timerFirstPaint': 41,
+        'timerWindowLoad': 1005,
+        'inner_timestamp': 1487862372503,
+        'fx_version': None,
+        'creation_date': None,
+        'test': u'pulse@mozilla.com',
+        'variants': None,
+        'timestamp': 76543,
+        'version': u'1.0.2',
+        'requests': requests,
+        'disconnectRequests': 1,
+        'consoleErrors': 0,
+        'e10sStatus': 1,
+        'e10sProcessCount': 4,
+        'trackingProtection': False
+    }
+
+    assert row_to_dict(actual) == expected

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,23 @@
+import pytest
+from pyspark.sql import SparkSession
+
+
+@pytest.fixture(scope="session")
+def spark_context(request):
+    """Initialize a spark context"""
+    spark = (SparkSession
+             .builder
+             .appName("python_etl_test")
+             .getOrCreate())
+
+    sc = spark.sparkContext
+
+    # teardown
+    request.addfinalizer(lambda: spark.stop())
+
+    return sc
+
+
+def row_to_dict(row):
+    """Convert pyspark.Row to dict for easier unordered comparison"""
+    return {key: row[key] for key in row.__fields__}


### PR DESCRIPTION
These jobs are currently running on ATMO. We'd like to get these jobs
reviewed and running on Airflow.

basic_etl was previously in it's own repository
[here](https://github.com/harterrt/betl) but will now be maintained in
this repository.