### PR TITLE
Add simple wrapper to pulse etl job

### DIFF
--- a/scheduling/pulse.py
+++ b/scheduling/pulse.py
@@ -1,0 +1,15 @@
+import os
+from pyspark import SparkConf, SparkContext
+from pyspark.sql import SQLContext
+from python_etl.testpilot import pulse
+
+if __name__ == "__main__":
+    conf = SparkConf().setAppName('pulse_etl')
+    sc = SparkContext(conf=conf)
+    sqlContext = SQLContext(sc)
+
+    # Make bdist_egg available to executer nodes
+    sc.addPyFile(os.path.join('dist', os.listdir('dist')[0]))
+
+    # Run job
+    pulse.etl_job(sc, sqlContext)


### PR DESCRIPTION
This allows us to schedule the job from Airflow. Later today I plan on
moving this code into the package and generalizing with a click CLI
wrapper.